### PR TITLE
Make some tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,21 @@ created daily.
 
     automated-ebs-snapshots --config ~/auto-ebs-snapshots.conf --watch vol-12345678 --interval daily
 
+Add volumes to watch list
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To add lots of volumes in one time, we can create a configuration file to define volumes(support volume id or Name tag), interval and retention.
+::
+
+  vol-d9d6d6af,weekly,2
+  volume1,weekly,4
+  volume2,daily,0
+
+Then run the following command
+::
+
+    automated-ebs-snapshots --config ~/auto-ebs-snapshots.conf --watch-file volumes.conf
+
 List watched volumes
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -80,6 +95,22 @@ To stop creating automated backups for a volume, run this:
 ::
 
     automated-ebs-snapshots --config ~/automated-ebs-snapshots.conf --unwatch vol-12345678
+
+Remove volumes from watch list
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To remove all volumes in the configuration file, just run:
+::
+
+    automated-ebs-snapshots --config ~/auto-ebs-snapshots.conf --unwatch-file volumes.conf
+
+List snapshots for a volume
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+List all snapshots for the given volume id or volume name
+::
+
+    automated-ebs-snapshots --config ~/automated-ebs-snapshots.conf --snapshots vol-d9d6d6af
 
 Creating snapshots
 ------------------

--- a/automated_ebs_snapshots/__init__.py
+++ b/automated_ebs_snapshots/__init__.py
@@ -155,6 +155,15 @@ def main():
     if args.unwatch:
         volume_manager.unwatch(connection, args.unwatch)
 
+    if args.watch_file:
+        volume_manager.watch_from_file(connection, args.watch_file)
+
+    if args.unwatch_file:
+        volume_manager.unwatch_from_file(connection, args.unwatch_file)
+
+    if args.snapshots:
+        volume_manager.list_snapshots(connection, args.snapshots)
+
     if args.list:
         volume_manager.list(connection)
 

--- a/automated_ebs_snapshots/command_line_options.py
+++ b/automated_ebs_snapshots/command_line_options.py
@@ -74,6 +74,23 @@ admin_actions_ag.add_argument(
     help=(
         'Add a new EBS volume to the watch list. '
         'Usage: --watch vol-12345678'))
+admin_actions_ag.add_argument(
+    '--snapshots',
+    metavar='VOLUME',
+    help='List all snapshots of this EBS volume')
+admin_actions_ag.add_argument(
+    '--unwatch-file',
+    metavar='FILE_NAME',
+    help=(
+        'Remove all EBS volumes in the config file from the watch list. '
+        'Usage: --unwatch-file volumes.conf'))
+admin_actions_ag.add_argument(
+    '--watch-file',
+    metavar='FILE_NAME',
+    help=(
+        'Add all EBS volumes in the config file to the watch list. '
+        'Usage: --watch-file volumes.conf'))
+
 actions_ag = parser.add_argument_group(
     title='Actions')
 actions_ag.add_argument(

--- a/automated_ebs_snapshots/volume_manager.py
+++ b/automated_ebs_snapshots/volume_manager.py
@@ -153,18 +153,22 @@ def watch(connection, volume_id, interval='daily', retention=0):
 
 def get_volume_id(connection, volume):
     """
-    Input can be Volume ID or Volume name. Return Volume ID
+    Get Volume ID from the given volume. Input can be volume id
+    or its Name tag.
 
     :type connection: boto.ec2.connection.EC2Connection
     :param connection: EC2 connection object
     :type volume: str
     :param volume: Volume ID or Volume Name
-    :returns: Volume ID or None if volume does not exist
+    :returns: Volume ID or None if the given volume does not exist
     """
+    # Regular expression to check whether input is a volume id
     volume_id_pattern = re.compile('vol-\w{8}')
+
     if volume_id_pattern.match(volume):
         # input is volume id
         try:
+            # Check whether it exists
             connection.get_all_volumes(volume_ids=[volume])
             volume_id = volume
         except EC2ResponseError:
@@ -180,6 +184,7 @@ def get_volume_id(connection, volume):
         if len(volumes) > 1:
             logger.warning('Volume {} not unique'.format(volume))
         volume_id = volumes[0].id
+
     return volume_id
 
 
@@ -221,6 +226,12 @@ def unwatch_from_file(connection, file_name):
 
 def list_snapshots(connection, volume):
     """ List all snapshots for the volume
+
+    :type connection: boto.ec2.connection.EC2Connection
+    :param connection: EC2 connection object
+    :type volume: str
+    :param volume: Volume ID or Volume Name
+    :returns: None
     """
 
     logger.info(

--- a/volumes.conf
+++ b/volumes.conf
@@ -1,0 +1,13 @@
+vol-d9d6d6af,weekly,2
+vol-0c9e807a,weekly,4
+vol-d19e80a7,weekly,1
+vol-2b9f815d,weekly,2
+vol-d6872b9f,weekly,2
+vol-9d872bd4,daily,2
+vol-d676c69f,weekly,2
+vol-fa76c6b3,weekly,3
+vol-c99a1f80,weekly,2
+vol-869a1fcf,monthly,2
+vol-efc602a4,weekly,2
+vol-8ec602c5,daily,2
+vol-dfd84b90,weekly,2

--- a/volumes.conf
+++ b/volumes.conf
@@ -1,13 +1,3 @@
 vol-d9d6d6af,weekly,2
-vol-0c9e807a,weekly,4
-vol-d19e80a7,weekly,1
-vol-2b9f815d,weekly,2
-vol-d6872b9f,weekly,2
-vol-9d872bd4,daily,2
-vol-d676c69f,weekly,2
-vol-fa76c6b3,weekly,3
-vol-c99a1f80,weekly,2
-vol-869a1fcf,monthly,2
-vol-efc602a4,weekly,2
-vol-8ec602c5,daily,2
-vol-dfd84b90,weekly,2
+volume1,weekly,4
+volume2,daily,0


### PR DESCRIPTION
Thanks for providing such useful tool. 

When I use your tool to backup EBS volumes, I found two problems:

1. It's inconvenient to add a large amount of volumes by running command one by one;
2. It's difficult to remember volume IDs. It would be better to use name tags.

To solve these problems, I modified your code:

1. Support using `tag:Name` to filter volumes;
2. Add new options `--watch-file` and `--unwatch-file` to read volumes from a configuration file.

I also add a new option `--snapshots` to list all snapshots for a given volume id or volume name.

I also updated `README.rst` and it shows how new options work.