### PR TITLE
Add support to always take a snapshot on run

### DIFF
--- a/automated_ebs_snapshots/__init__.py
+++ b/automated_ebs_snapshots/__init__.py
@@ -169,3 +169,6 @@ def main():
 
     if args.run:
         snapshot_manager.run(connection)
+
+    if args.forcerun:
+        snapshot_manager.run(connection, force=True)

--- a/automated_ebs_snapshots/command_line_options.py
+++ b/automated_ebs_snapshots/command_line_options.py
@@ -97,6 +97,13 @@ actions_ag.add_argument(
     '--run',
     action='count',
     help='Run the watcher to ensure snapshots')
+
+actions_ag.add_argument(
+    '--forcerun',
+    action='count',
+    help='Similar to --run, but always take a snapshot and purge '
+         'snapshots that should be removed.')
+
 args = parser.parse_args()
 
 if args.version:

--- a/automated_ebs_snapshots/snapshot_manager.py
+++ b/automated_ebs_snapshots/snapshot_manager.py
@@ -10,7 +10,7 @@ from automated_ebs_snapshots.valid_intervals import VALID_INTERVALS
 logger = logging.getLogger(__name__)
 
 
-def run(connection):
+def run(connection, force=False):
     """ Ensure that we have snapshots for a given volume
 
     :type connection: boto.ec2.connection.EC2Connection
@@ -20,7 +20,7 @@ def run(connection):
     volumes = volume_manager.get_watched_volumes(connection)
 
     for volume in volumes:
-        _ensure_snapshot(connection, volume)
+        _ensure_snapshot(connection, volume, force)
         _remove_old_snapshots(connection, volume)
 
 
@@ -40,7 +40,7 @@ def _create_snapshot(volume):
     return snapshot
 
 
-def _ensure_snapshot(connection, volume):
+def _ensure_snapshot(connection, volume, force):
     """ Ensure that a given volume has an appropriate snapshot
 
     :type connection: boto.ec2.connection.EC2Connection
@@ -64,8 +64,8 @@ def _ensure_snapshot(connection, volume):
 
     snapshots = connection.get_all_snapshots(filters={'volume-id': volume.id})
 
-    # Create a snapshot if we don't have any
-    if not snapshots:
+    # Create a snapshot if there are not already any or if forced
+    if not snapshots or force:
         _create_snapshot(volume)
         return
 


### PR DESCRIPTION
Previously, running via --run with a scheduled snapshot it
is wrongly missing every other snapshot as it is usually a
second too young to be considered stale.

This change adds a --forcerun option to always take a
snapshot (irrelevant of age) and then purge any snapshots due
to be purged as usual.

fixes skymill/automated-ebs-snapshots#23

Signed-off-by: Dave Walker (Daviey) email@daviey.com
